### PR TITLE
Use local and ip address to create vxlan interface

### DIFF
--- a/neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py
@@ -328,7 +328,7 @@ class LinuxBridgeManager(amb.CommonAgentManagerBase):
                       "VNI %(segmentation_id)s",
                       {'interface': interface,
                        'segmentation_id': segmentation_id})
-            args = {'dev': self.local_int,
+            args = {'local': self.local_ip,
                     'srcport': (cfg.CONF.VXLAN.udp_srcport_min,
                                 cfg.CONF.VXLAN.udp_srcport_max),
                     'dstport': cfg.CONF.VXLAN.udp_dstport,


### PR DESCRIPTION
Linux kernel does not allow a loopback interface to be an endpoint dev interface for VXLAN terminations. In order to allow loopback interfaces to be VXLAN termination endpoints, we need to change how the vxlan is created: don't use dev, use local and an ip address. Using local is also, perhaps, a more flexible solution, since it allows for picking the specific IP on the interface, as opposed to whatever the OS decides to use.